### PR TITLE
gziphandler: Implemented more informative errors (adammck's TODO)

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -35,24 +35,6 @@ func (e *ErrorList) Error() string {
 	return fmt.Sprintf("%d errors", len(*e))
 }
 
-// Append appends an error to the error list.
-func (e *ErrorList) Append(err interface{}) {
-	// Should this be a method on a pointer to a slice, or just
-	// a slice?
-	switch err := err.(type) {
-	case KeyError:
-		*e = append(*e, err)
-	case *KeyError:
-		*e = append(*e, *err)
-	case *ErrorList:
-		*e = append(*e, *err...)
-	case ErrorList:
-		*e = append(*e, err...)
-	default:
-		return
-	}
-}
-
 // The default qvalue to assign to an encoding if no explicit qvalue is set.
 // This is actually kind of ambiguous in RFC 2616, so hopefully it's correct.
 // The examples seem to indicate that it is.
@@ -105,7 +87,7 @@ func acceptsGzip(r *http.Request) bool {
 // works.
 //
 // See: http://tools.ietf.org/html/rfc2616#section-14.3
-func parseEncodings(s string) (codings, ErrorList) {
+func parseEncodings(s string) (codings, error) {
 	c := make(codings)
 	e := make(ErrorList, 0)
 
@@ -113,7 +95,7 @@ func parseEncodings(s string) (codings, ErrorList) {
 		coding, qvalue, err := parseCoding(ss)
 
 		if err != nil {
-			e.Append(KeyError{ss, err})
+			e = append(e, KeyError{ss, err})
 
 		} else {
 			c[coding] = qvalue
@@ -121,7 +103,7 @@ func parseEncodings(s string) (codings, ErrorList) {
 	}
 
 	if len(e) > 0 {
-		return c, e
+		return c, &e
 	}
 
 	return c, nil

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -112,15 +112,20 @@ func TestMultiError(t *testing.T) {
 		}},
 	}
 
-	masterList := new(ErrorList)
+	masterList := make(ErrorList, 0)
 	for _, eg := range tests {
-		_, errList := parseEncodings(eg)
+		_, err := parseEncodings(eg)
 
-		masterList.Append(errList)
+		if errList, ok := err.(*ErrorList); ok {
+			for _, e := range *errList {
+				masterList = append(masterList, e)
+			}
+
+		}
 	}
 
-	if !equalErrorSlice(*masterList, want) {
-		t.Errorf("Slices do not match %+v\n\n%+v", *masterList, want)
+	if !equalErrorSlice(masterList, want) {
+		t.Errorf("Slices do not match %+v\n\n%+v", masterList, want)
 	}
 
 	assert.Equal(t, "6 errors", masterList.Error())


### PR DESCRIPTION
gzip.go: Added a couple new types:
- ErrorList, a slice of 
- KeyError, a small struct with the error and the content that
  caused the error
- ErrEmptyContentCoding, an error if the Accept-Encoding header is empty
- Function Append, which appends an ErrorList or KeyError to an 
- Function Error for both ErrorList and KeyError, which returns
  a formatted error string describing the error(s).

gzip_test.go: Added testing for errors
