### PR TITLE
Use standard Vary response header

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 )
 
+const (
+	vary            = "Vary"
+	acceptEncoding  = "Accept-Encoding"
+	contentEncoding = "Content-Encoding"
+)
+
 type codings map[string]float64
 
 // The default qvalue to assign to an encoding if no explicit qvalue is set.
@@ -33,6 +39,8 @@ func (gzw GzipResponseWriter) Write(b []byte) (int, error) {
 // the client supports it (via the Accept-Encoding header).
 func GzipHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add(vary, acceptEncoding)
+
 		if acceptsGzip(r) {
 
 			// Bytes written during ServeHTTP are redirected to this gzip writer
@@ -40,7 +48,7 @@ func GzipHandler(h http.Handler) http.Handler {
 			gzw := gzip.NewWriter(w)
 			defer gzw.Close()
 
-			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set(contentEncoding, "gzip")
 			h.ServeHTTP(GzipResponseWriter{gzw, w}, r)
 
 		} else {
@@ -52,7 +60,7 @@ func GzipHandler(h http.Handler) http.Handler {
 // acceptsGzip returns true if the given HTTP request indicates that it will
 // accept a gzippped response.
 func acceptsGzip(r *http.Request) bool {
-	acceptedEncodings, _ := parseEncodings(r.Header.Get("Accept-Encoding"))
+	acceptedEncodings, _ := parseEncodings(r.Header.Get(acceptEncoding))
 	return acceptedEncodings["gzip"] > 0.0
 }
 

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -3,11 +3,12 @@ package gziphandler
 import (
 	"bytes"
 	"compress/gzip"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseEncodings(t *testing.T) {
@@ -49,6 +50,7 @@ func TestGzipHandler(t *testing.T) {
 
 	assert.Equal(t, 200, res1.Code)
 	assert.Equal(t, "", res1.Header().Get("Content-Encoding"))
+	assert.Equal(t, "Accept-Encoding", res1.Header().Get("Vary"))
 	assert.Equal(t, testBody, res1.Body.String())
 
 	// but requests with accept-encoding:gzip are compressed if possible
@@ -60,6 +62,7 @@ func TestGzipHandler(t *testing.T) {
 
 	assert.Equal(t, 200, res2.Code)
 	assert.Equal(t, "gzip", res2.Header().Get("Content-Encoding"))
+	assert.Equal(t, "Accept-Encoding", res2.Header().Get("Vary"))
 	assert.Equal(t, gzipStr(testBody), res2.Body.Bytes())
 }
 


### PR DESCRIPTION
Responses should acknowledge Accept-Encoding - https://www.maxcdn.com/blog/accept-encoding-its-vary-important/