### PR TITLE
Close gzip Writer before putting back into pool

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -52,10 +52,11 @@ func GzipHandler(h http.Handler) http.Handler {
 			// before being written to the underlying response.
 			gzw := gzipWriterPool.Get().(*gzip.Writer)
 			gzw.Reset(w)
-			defer gzw.Close()
 
 			w.Header().Set(contentEncoding, "gzip")
 			h.ServeHTTP(GzipResponseWriter{gzw, w}, r)
+
+			gzw.Close()
 			gzipWriterPool.Put(gzw)
 		} else {
 			h.ServeHTTP(w, r)


### PR DESCRIPTION
When using: 
```go
defer gzw.Close()
```
The gzip.Writer was being closed **after** being put back into the pool of writers.

As per: https://golang.org/pkg/compress/gzip/#Writer.Close, calling Close flushes any unwritten data to the underlying io.Writer. This should happen before being placed back into the pool to be used by another connection. 