### PR TITLE
Case sensitive package name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ package main
 import (
 	"io"
 	"net/http"
-	"github.com/nytimes/gziphandler"
+	"github.com/NYTimes/gziphandler"
 )
 
 func main() {


### PR DESCRIPTION
Although it does not matter for go if you do `go get github.com/NYTimes/gziphandler` or `go get github.com/nytimesimes/gziphandler` you might end up with two copies of your library in your $GOPATH depending where you copy the package path from. (example from README or browser url)