### PR TITLE
Use deferred Gzip closing

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -47,17 +47,15 @@ func GzipHandler(h http.Handler) http.Handler {
 		w.Header().Add(vary, acceptEncoding)
 
 		if acceptsGzip(r) {
-
 			// Bytes written during ServeHTTP are redirected to this gzip writer
 			// before being written to the underlying response.
 			gzw := gzipWriterPool.Get().(*gzip.Writer)
+			defer gzipWriterPool.Put(gzw)
 			gzw.Reset(w)
+			defer gzw.Close()
 
 			w.Header().Set(contentEncoding, "gzip")
 			h.ServeHTTP(GzipResponseWriter{gzw, w}, r)
-
-			gzw.Close()
-			gzipWriterPool.Put(gzw)
 		} else {
 			h.ServeHTTP(w, r)
 		}


### PR DESCRIPTION
When there is something to close, use deferred functions.
Otherwise, in this case, the Gzip writer will never be closed nor put back in the pool if a downstream handler panics.

Of course, we still close the writer **before** putting it back in the pool as deferred function calls are LIFO executed.

Also, `DEFAULT_QVALUE` should be changed to `DefaultQvalue` and `e := make([]string, 0)` to `var e []string`.