### PR TITLE
Automatically infer content type of response

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -36,6 +36,10 @@ type GzipResponseWriter struct {
 
 // Write appends data to the gzip writer.
 func (w GzipResponseWriter) Write(b []byte) (int, error) {
+	if _, ok := w.Header()["Content-Type"]; !ok {
+		// If content type is not set, infer it from the uncompressed body.
+		w.Header().Set("Content-Type", http.DetectContentType(b))
+	}
 	return w.gw.Write(b)
 }
 

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -62,6 +62,15 @@ func TestGzipHandler(t *testing.T) {
 	assert.Equal(t, "gzip", res2.Header().Get("Content-Encoding"))
 	assert.Equal(t, "Accept-Encoding", res2.Header().Get("Vary"))
 	assert.Equal(t, gzipStr(testBody), res2.Body.Bytes())
+
+	// content-type header is correctly set based on uncompressed body
+
+	req3, _ := http.NewRequest("GET", "/whatever", nil)
+	req3.Header.Set("Accept-Encoding", "gzip")
+	res3 := httptest.NewRecorder()
+	handler.ServeHTTP(res3, req3)
+
+	assert.Equal(t, http.DetectContentType([]byte(testBody)), res3.Header().Get("Content-Type"))
 }
 
 // --------------------------------------------------------------------
@@ -120,7 +129,6 @@ func runBenchmark(b *testing.B, req *http.Request, handler http.Handler) {
 
 func newTestHandler(body string) http.Handler {
 	return GzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
 		io.WriteString(w, body)
 	}))
 }


### PR DESCRIPTION
When using the `net/http` server, if the "Content-Type" header of the response is not set at the time that it the response is served the `http` package will [automatically try to sniff the content type](https://golang.org/pkg/net/http/#ServeContent). When using `gziphandler`, if the response is gzip compressed it will set the `Content-Type` of the response to be `application/x-gzip`.

This can be surprising for developers that rely on the behavior of `ServeContent` to apply the correct `Content-Type` header. Having an incorrect content-type header can cause unexpected behavior, depending on the browser.

 Ideally the wrapped handler should set the `Content-Type` before returning, but since the standard library automatically handles this I thought it would be a good idea to have the same behavior preserved by `GzipResponseWriter `.  