### PR TITLE
Use gzipWriterPools index rather then gzip level in GzipResponseWriter

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -13,6 +13,8 @@ const (
 	vary            = "Vary"
 	acceptEncoding  = "Accept-Encoding"
 	contentEncoding = "Content-Encoding"
+	contentType     = "Content-Type"
+	contentLength   = "Content-Length"
 )
 
 type codings map[string]float64
@@ -57,8 +59,8 @@ func addLevelPool(level int) {
 }
 
 // GzipResponseWriter provides an http.ResponseWriter interface, which gzips
-// bytes before writing them to the underlying response. This doesn't set the
-// Content-Encoding header, nor close the writers, so don't forget to do that.
+// bytes before writing them to the underlying response. This doesn't close the
+// writers, so don't forget to do that.
 type GzipResponseWriter struct {
 	http.ResponseWriter
 	level int
@@ -73,9 +75,9 @@ func (w *GzipResponseWriter) Write(b []byte) (int, error) {
 		w.init()
 	}
 
-	if _, ok := w.Header()["Content-Type"]; !ok {
+	if _, ok := w.Header()[contentType]; !ok {
 		// If content type is not set, infer it from the uncompressed body.
-		w.Header().Set("Content-Type", http.DetectContentType(b))
+		w.Header().Set(contentType, http.DetectContentType(b))
 	}
 	return w.gw.Write(b)
 }
@@ -99,6 +101,10 @@ func (w *GzipResponseWriter) init() {
 	gzw.Reset(w.ResponseWriter)
 	w.gw = gzw
 	w.ResponseWriter.Header().Set(contentEncoding, "gzip")
+	// if the Content-Length is already set, then calls to Write on gzip
+	// will fail to set the Content-Length header since its already set
+	// See: https://github.com/golang/go/issues/14975
+	w.ResponseWriter.Header().Del(contentLength)
 }
 
 // Close will close the gzip.Writer and will put it back in the gzipWriterPool.

--- a/gzip.go
+++ b/gzip.go
@@ -63,7 +63,7 @@ func addLevelPool(level int) {
 // writers, so don't forget to do that.
 type GzipResponseWriter struct {
 	http.ResponseWriter
-	level int
+	index int // Index for gzipWriterPools.
 	gw    *gzip.Writer
 }
 
@@ -97,7 +97,7 @@ func (w *GzipResponseWriter) WriteHeader(code int) {
 func (w *GzipResponseWriter) init() {
 	// Bytes written during ServeHTTP are redirected to this gzip writer
 	// before being written to the underlying response.
-	gzw := gzipWriterPools[poolIndex(w.level)].Get().(*gzip.Writer)
+	gzw := gzipWriterPools[w.index].Get().(*gzip.Writer)
 	gzw.Reset(w.ResponseWriter)
 	w.gw = gzw
 	w.ResponseWriter.Header().Set(contentEncoding, "gzip")
@@ -114,7 +114,7 @@ func (w *GzipResponseWriter) Close() error {
 	}
 
 	err := w.gw.Close()
-	gzipWriterPools[poolIndex(w.level)].Put(w.gw)
+	gzipWriterPools[w.index].Put(w.gw)
 	return err
 }
 
@@ -152,13 +152,15 @@ func NewGzipLevelHandler(level int) (func(http.Handler) http.Handler, error) {
 		return nil, fmt.Errorf("invalid compression level requested: %d", level)
 	}
 	return func(h http.Handler) http.Handler {
+		index := poolIndex(level)
+
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Add(vary, acceptEncoding)
 
 			if acceptsGzip(r) {
 				gw := &GzipResponseWriter{
 					ResponseWriter: w,
-					level:          level,
+					index:          index,
 				}
 				defer gw.Close()
 


### PR DESCRIPTION
This removes the need to calculate the index on every request.