### PR TITLE
Add support to skiping gzip for small responses. Fixes #24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 
 go:
-  - 1.7
+  - 1.x
   - tip

--- a/gzip.go
+++ b/gzip.go
@@ -186,7 +186,7 @@ func NewGzipLevelAndMinSize(level, askedMinSize int) (func(http.Handler) http.Ha
 		return nil, fmt.Errorf("invalid compression level requested: %d", level)
 	}
 	if askedMinSize < 0 {
-		return nil, fmt.Errorf("Minimum size must be more than zero")
+		return nil, fmt.Errorf("minimum size must be more than zero")
 	}
 	return func(h http.Handler) http.Handler {
 		index := poolIndex(level)

--- a/gzip.go
+++ b/gzip.go
@@ -21,10 +21,10 @@ const (
 
 type codings map[string]float64
 
-// The default qvalue to assign to an encoding if no explicit qvalue is set.
+// DefaultQVALUE is the default qvalue to assign to an encoding if no explicit qvalue is set.
 // This is actually kind of ambiguous in RFC 2616, so hopefully it's correct.
 // The examples seem to indicate that it is.
-const DEFAULT_QVALUE = 1.0
+const DefaultQVALUE = 1.0
 
 // gzipWriterPools stores a sync.Pool for each compression level for reuse of
 // gzip.Writers. Use poolIndex to covert a compression level to an index into
@@ -247,7 +247,7 @@ func parseEncodings(s string) (codings, error) {
 func parseCoding(s string) (coding string, qvalue float64, err error) {
 	for n, part := range strings.Split(s, ";") {
 		part = strings.TrimSpace(part)
-		qvalue = DEFAULT_QVALUE
+		qvalue = DefaultQVALUE
 
 		if n == 0 {
 			coding = strings.ToLower(part)


### PR DESCRIPTION
This make possible to skip compression if the response is smaller than the specified size.