### PR TITLE
Minimum size not compatible with template package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 
 go:
-  - 1.x
+  - 1.7
   - tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 
 go:
-  - 1.7
+  - 1.x
   - tip

--- a/gzip.go
+++ b/gzip.go
@@ -87,21 +87,21 @@ func (w *GzipResponseWriter) Write(b []byte) (int, error) {
 	// Update the numbers of bytes written.
 	w.bytesWritten += len(b)
 
-	if _, ok := w.ResponseWriter.Header()[contentType]; !ok {
+	if _, ok := w.Header()[contentType]; !ok {
 		// If content type is not set, infer it from the uncompressed body.
-		w.ResponseWriter.Header().Set(contentType, http.DetectContentType(b))
+		w.Header().Set(contentType, http.DetectContentType(b))
 	}
 
 	// If the global write is bigger than the minSize, compression is used.
 	// Otherwise it save the write into a buffer and send it with the regular
 	// ResponseWriter at close.
 	if w.bytesWritten > w.minSize {
-		w.ResponseWriter.Header().Set(contentEncoding, "gzip")
+		w.Header().Set(contentEncoding, "gzip")
 
 		// if the Content-Length is already set, then calls to Write on gzip
 		// will fail to set the Content-Length header since its already set
 		// See: https://github.com/golang/go/issues/14975
-		w.ResponseWriter.Header().Del(contentLength)
+		w.Header().Del(contentLength)
 
 		// Write the header and contentEncoding to gzip.
 		w.writeHeader()
@@ -155,7 +155,7 @@ func (w *GzipResponseWriter) writeHeader() {
 	if w.code == 0 {
 		w.code = http.StatusOK
 	}
-	w.ResponseWriter.WriteHeader(w.code)
+	w.WriteHeader(w.code)
 }
 
 // init graps a new gzip writer from the gzipWriterPool and writes the correct

--- a/gzip.go
+++ b/gzip.go
@@ -186,7 +186,7 @@ func NewGzipLevelAndMinSize(level, askedMinSize int) (func(http.Handler) http.Ha
 		return nil, fmt.Errorf("invalid compression level requested: %d", level)
 	}
 	if askedMinSize < 0 {
-		return nil, fmt.Errorf("Minimum size must be more than zero")
+		return nil, fmt.Errorf("minimum size must be more than zero")
 	}
 	return func(h http.Handler) http.Handler {
 		index := poolIndex(level)

--- a/gzip.go
+++ b/gzip.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"compress/gzip"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -73,58 +72,93 @@ func addLevelPool(level int) {
 // It can be configured to skip response smaller than minSize.
 type GzipResponseWriter struct {
 	http.ResponseWriter
-	index        int // Index for gzipWriterPools.
-	gw           *gzip.Writer
-	minSize      int       // Specifed the minimum response size to gzip. Only the first Write call is checked.
-	chosenWriter io.Writer // After the first Write call the ResponseWriter must use the same writer.
+	index int // Index for gzipWriterPools.
+	gw    *gzip.Writer
+
+	minSize      int    // Specifed the minimum response size to gzip. Only the first Write call is checked.
+	buff         []byte // Holds the first part of the write before the reaching the minSize or the end of the write.
+	bytesWritten int    // Keep trace of the numbers of bytes written.
 }
 
 // Write appends data to the gzip writer.
 func (w *GzipResponseWriter) Write(b []byte) (int, error) {
-	// If a partial response have been send, the next response will use the same writer.
-	if w.chosenWriter != nil {
-		return w.chosenWriter.Write(b)
-	}
-
-	// If b is smaller than the minSize, the regular writer is used.
-	if len(b) < w.minSize {
-		w.chosenWriter = w.ResponseWriter
-		return w.ResponseWriter.Write(b)
-	}
-
-	// Lazily create the gzip.Writer, this allows empty bodies to be actually
-	// empty, for example in the case of status code 204 (no content).
-	if w.gw == nil {
-		w.init()
-	}
-	w.chosenWriter = w.gw
+	// Update the numbers of bytes written.
+	w.bytesWritten += len(b)
 
 	if _, ok := w.Header()[contentType]; !ok {
 		// If content type is not set, infer it from the uncompressed body.
 		w.Header().Set(contentType, http.DetectContentType(b))
 	}
-	return w.gw.Write(b)
+
+	// If the global write is bigger than the minSize, compression is used.
+	// Otherwise it save the write into a buffer and send it with the regular
+	// ResponseWriter at close.
+	if w.bytesWritten > w.minSize {
+		fmt.Println("open GZIP", w.bytesWritten > w.minSize, w.bytesWritten, w.minSize, len(b))
+		n := 0
+		// Lazily create the gzip.Writer, this allows empty bodies to be actually
+		// empty, for example in the case of status code 204 (no content).
+		if w.buff != nil {
+			w.init()
+			n1, err := w.gw.Write(w.buff)
+			if err != nil {
+				return n, err
+			}
+			n += n1
+		}
+
+		// tmpBuff := w.buff
+		w.buff = nil
+
+		if w.gw == nil {
+			w.init()
+		}
+
+		n1, err := w.gw.Write(b)
+		if err != nil {
+			return n, err
+		}
+
+		// fmt.Println("wrote:", string(tmpBuff), string(b))
+
+		n += n1
+		return n, err
+	}
+
+	// if w.buff == nil {
+	// 	w.buff = bytes.NewBuffer(nil)
+	// }
+
+	fmt.Println("TPM")
+
+	w.buff = append(w.buff, b...)
+	fmt.Println("tmpBuff:", string(w.buff))
+	return 0, nil
 }
 
 // WriteHeader will check if the gzip writer needs to be lazily initiated and
 // then pass the code along to the underlying ResponseWriter.
 func (w *GzipResponseWriter) WriteHeader(code int) {
-	if w.gw == nil &&
-		code != http.StatusNotModified && code != http.StatusNoContent {
-		w.init()
-	}
+	fmt.Println("write header")
+	// if w.gw == nil &&
+	// 	code != http.StatusNotModified && code != http.StatusNoContent {
+	// 	w.init()
+	// }
 	w.ResponseWriter.WriteHeader(code)
 }
 
 // init graps a new gzip writer from the gzipWriterPool and writes the correct
 // content encoding header.
 func (w *GzipResponseWriter) init() {
+	fmt.Println("init GzipResponseWriter")
+
 	// Bytes written during ServeHTTP are redirected to this gzip writer
 	// before being written to the underlying response.
 	gzw := gzipWriterPools[w.index].Get().(*gzip.Writer)
 	gzw.Reset(w.ResponseWriter)
 	w.gw = gzw
-	w.ResponseWriter.Header().Set(contentEncoding, "gzip")
+
+	w.Header().Set(contentEncoding, "gzip")
 	// if the Content-Length is already set, then calls to Write on gzip
 	// will fail to set the Content-Length header since its already set
 	// See: https://github.com/golang/go/issues/14975
@@ -133,6 +167,14 @@ func (w *GzipResponseWriter) init() {
 
 // Close will close the gzip.Writer and will put it back in the gzipWriterPool.
 func (w *GzipResponseWriter) Close() error {
+	if w.buff != nil {
+		fmt.Println("close REGULAR:", string(w.buff))
+		w.ResponseWriter.Write(w.buff)
+		return nil
+	}
+
+	fmt.Println("close GZIP")
+
 	if w.gw == nil {
 		return nil
 	}
@@ -203,12 +245,15 @@ func NewGzipLevelAndMinSize(level, askedMinSize int) (func(http.Handler) http.Ha
 			w.Header().Add(vary, acceptEncoding)
 
 			if acceptsGzip(r) {
+				fmt.Println("start gziper:", r.URL.Path)
 				gw := &GzipResponseWriter{
 					ResponseWriter: w,
 					index:          index,
 					minSize:        askedMinSize,
 				}
 				defer gw.Close()
+
+				gw.init()
 
 				h.ServeHTTP(gw, r)
 			} else {

--- a/gzip.go
+++ b/gzip.go
@@ -151,6 +151,7 @@ func (w *GzipResponseWriter) WriteHeader(code int) {
 
 // writeHeader uses the saved code to send it to the ResponseWriter.
 func (w *GzipResponseWriter) writeHeader() {
+	// debug.PrintStack()
 	if w.code == 0 {
 		w.code = http.StatusOK
 	}
@@ -175,7 +176,6 @@ func (w *GzipResponseWriter) Close() error {
 		w.ResponseWriter.Write(w.buff)
 		return nil
 	}
-	w.writeHeader()
 
 	if w.gw == nil {
 		return nil

--- a/gzip.go
+++ b/gzip.go
@@ -21,10 +21,10 @@ const (
 
 type codings map[string]float64
 
-// The default qvalue to assign to an encoding if no explicit qvalue is set.
+// DefaultQVALUE is the default qvalue to assign to an encoding if no explicit qvalue is set.
 // This is actually kind of ambiguous in RFC 2616, so hopefully it's correct.
 // The examples seem to indicate that it is.
-const DEFAULT_QVALUE = 1.0
+const DefaultQVALUE = 1.0
 
 // gzipWriterPools stores a sync.Pool for each compression level for reuse of
 // gzip.Writers. Use poolIndex to covert a compression level to an index into
@@ -247,7 +247,7 @@ func parseEncodings(s string) (codings, error) {
 func parseCoding(s string) (coding string, qvalue float64, err error) {
 	for n, part := range strings.Split(s, ";") {
 		part = strings.TrimSpace(part)
-		qvalue = DEFAULT_QVALUE
+		qvalue = DefaultQVALUE
 
 		if n == 0 {
 			coding = strings.ToLower(part)

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -216,7 +216,6 @@ func TestGzipHandlerContentLength(t *testing.T) {
 }
 
 func TestGzipHandlerMinSize(t *testing.T) {
-
 	wrapper, _ := NewGzipLevelAndMinSize(gzip.DefaultCompression, 12)
 	handler := wrapper(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -221,6 +221,8 @@ func TestGzipHandlerMinSize(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			resp, _ := ioutil.ReadAll(r.Body)
 			w.Write(resp)
+			// Call write multiple times to pass through "chosenWriter"
+			w.Write(resp)
 		},
 	))
 

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -134,8 +134,8 @@ func TestGzipHandlerNoBody(t *testing.T) {
 		// Body must be empty.
 		{http.StatusNoContent, "", 0},
 		{http.StatusNotModified, "", 0},
-		// // Body is going to get gzip'd no matter what.
-		// {http.StatusOK, "gzip", 23},
+		// Body is going to get gzip'd no matter what.
+		{http.StatusOK, "", 0},
 	}
 
 	for num, test := range tests {

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -134,8 +134,8 @@ func TestGzipHandlerNoBody(t *testing.T) {
 		// Body must be empty.
 		{http.StatusNoContent, "", 0},
 		{http.StatusNotModified, "", 0},
-		// Body is going to get gzip'd no matter what.
-		{http.StatusOK, "gzip", 23},
+		// // Body is going to get gzip'd no matter what.
+		// {http.StatusOK, "gzip", 23},
 	}
 
 	for num, test := range tests {
@@ -237,7 +237,6 @@ func TestGzipHandlerMinSize(t *testing.T) {
 	handler.ServeHTTP(resp1, req1)
 	res1 := resp1.Result()
 
-	fmt.Println("res1:", res1.Header.Get(contentEncoding))
 	if res1.Header.Get(contentEncoding) == "gzip" {
 		t.Errorf("The response is compress and should not")
 		return
@@ -252,7 +251,6 @@ func TestGzipHandlerMinSize(t *testing.T) {
 	handler.ServeHTTP(resp2, req2)
 	res2 := resp2.Result()
 
-	fmt.Println("res2:", res2.Header.Get(contentEncoding))
 	if res2.Header.Get(contentEncoding) != "gzip" {
 		t.Errorf("The response is not compress and should")
 		return


### PR DESCRIPTION
- go 1.8
- Linux 64
- I using the package with templates
- I expect to see the template as it should :smiley:
- But I get the template with some special chars. It looks like bad decoding

The problem comes from the size limitation.

If the template package is used, it can calls Write multiple times with variable length.
In any case the response writer must be the same for the all response inside the same request. So the package as is, is not good.

I made some modifications to prevent using different response writers on successive calls.

But the size limitation become pretty pointless with template or other handlers calling multiple times the Write function.