### PR TITLE
support for H2 Push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: go
 
 go:
   - 1.7
+  - 1.8
   - tip

--- a/gzip_go18.go
+++ b/gzip_go18.go
@@ -4,24 +4,7 @@ package gziphandler
 
 import "net/http"
 
-// Push initiates an HTTP/2 server push. This constructs a synthetic
-// request using the given target and options, serializes that request
-// into a PUSH_PROMISE frame, then dispatches that request using the
-// server's request handler. If opts is nil, default options are used.
-//
-// The target must either be an absolute path (like "/path") or an absolute
-// URL that contains a valid host and the same scheme as the parent request.
-// If the target is a path, it will inherit the scheme and host of the
-// parent request.
-//
-// The HTTP/2 spec disallows recursive pushes and cross-authority pushes.
-// Push may or may not detect these invalid pushes; however, invalid
-// pushes will be detected and canceled by conforming clients.
-//
-// Handlers that wish to push URL X should call Push before sending any
-// data that may trigger a request for URL X. This avoids a race where the
-// client issues requests for X before receiving the PUSH_PROMISE for X.
-//
+// Push initiates an HTTP/2 server push.
 // Push returns ErrNotSupported if the client has disabled push or if push
 // is not supported on the underlying connection.
 func (w *GzipResponseWriter) Push(target string, opts *http.PushOptions) error {

--- a/gzip_go18.go
+++ b/gzip_go18.go
@@ -10,7 +10,34 @@ import "net/http"
 func (w *GzipResponseWriter) Push(target string, opts *http.PushOptions) error {
 	pusher, ok := w.ResponseWriter.(http.Pusher)
 	if ok && pusher != nil {
-		return pusher.Push(target, opts)
+		return pusher.Push(target, setAcceptEncodingForPushOptions(opts))
 	}
 	return http.ErrNotSupported
+}
+
+// setAcceptEncodingForPushOptions sets "Accept-Encoding" : "gzip" for PushOptions without overriding existing headers.
+func setAcceptEncodingForPushOptions(opts *http.PushOptions) *http.PushOptions {
+
+	if opts == nil {
+		opts = &http.PushOptions{
+			Header: http.Header{
+				acceptEncoding: []string{"gzip"},
+			},
+		}
+		return opts
+	}
+
+	if opts.Header == nil {
+		opts.Header = http.Header{
+			acceptEncoding: []string{"gzip"},
+		}
+		return opts
+	}
+
+	if encoding := opts.Header.Get(acceptEncoding); encoding == "" {
+		opts.Header.Add(acceptEncoding, "gzip")
+		return opts
+	}
+
+	return opts
 }

--- a/gzip_go18.go
+++ b/gzip_go18.go
@@ -1,0 +1,33 @@
+// +build go1.8
+
+package gziphandler
+
+import "net/http"
+
+// Push initiates an HTTP/2 server push. This constructs a synthetic
+// request using the given target and options, serializes that request
+// into a PUSH_PROMISE frame, then dispatches that request using the
+// server's request handler. If opts is nil, default options are used.
+//
+// The target must either be an absolute path (like "/path") or an absolute
+// URL that contains a valid host and the same scheme as the parent request.
+// If the target is a path, it will inherit the scheme and host of the
+// parent request.
+//
+// The HTTP/2 spec disallows recursive pushes and cross-authority pushes.
+// Push may or may not detect these invalid pushes; however, invalid
+// pushes will be detected and canceled by conforming clients.
+//
+// Handlers that wish to push URL X should call Push before sending any
+// data that may trigger a request for URL X. This avoids a race where the
+// client issues requests for X before receiving the PUSH_PROMISE for X.
+//
+// Push returns ErrNotSupported if the client has disabled push or if push
+// is not supported on the underlying connection.
+func (w *GzipResponseWriter) Push(target string, opts *http.PushOptions) error {
+	pusher, ok := w.ResponseWriter.(http.Pusher)
+	if ok && pusher != nil {
+		return pusher.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}

--- a/gzip_go18_test.go
+++ b/gzip_go18_test.go
@@ -1,0 +1,75 @@
+// +build go1.8
+
+package gziphandler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetAcceptEncodingForPushOptionsNilOpts(t *testing.T) {
+	var opts *http.PushOptions
+	opts = setAcceptEncodingForPushOptions(opts)
+
+	assert.NotNil(t, opts)
+	assert.NotNil(t, opts.Header)
+
+	for k, v := range opts.Header {
+		assert.Equal(t, "Accept-Encoding", k)
+		assert.Len(t, v, 1)
+		assert.Equal(t, "gzip", v[0])
+	}
+}
+
+func TestSetAcceptEncodingForPushOptionsNilHeader(t *testing.T) {
+	opts := &http.PushOptions{}
+	opts = setAcceptEncodingForPushOptions(opts)
+
+	assert.NotNil(t, opts)
+	assert.NotNil(t, opts.Header)
+
+	for k, v := range opts.Header {
+		assert.Equal(t, "Accept-Encoding", k)
+		assert.Len(t, v, 1)
+		assert.Equal(t, "gzip", v[0])
+	}
+}
+
+func TestSetAcceptEncodingForPushOptionsNoAcceptEncoding(t *testing.T) {
+	opts := &http.PushOptions{
+		Header: http.Header{
+			"User-Agent": []string{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36"},
+		},
+	}
+	opts = setAcceptEncodingForPushOptions(opts)
+
+	assert.NotNil(t, opts)
+	assert.NotNil(t, opts.Header)
+
+	assert.Equal(t, "gzip", opts.Header.Get("Accept-Encoding"))
+	assert.Equal(t, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36", opts.Header.Get("User-Agent"))
+}
+
+func TestSetAcceptEncodingForPushOptionsWithAcceptEncoding(t *testing.T) {
+
+	opts := &http.PushOptions{
+		Header: http.Header{
+			"User-Agent":   []string{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36"},
+			acceptEncoding: []string{"deflate"},
+		},
+	}
+	opts = setAcceptEncodingForPushOptions(opts)
+
+	assert.NotNil(t, opts)
+	assert.NotNil(t, opts.Header)
+
+	e, found := opts.Header["Accept-Encoding"]
+	if !found {
+		assert.Fail(t, "Missing Accept-Encoding header value")
+	}
+	assert.Len(t, e, 1)
+	assert.Equal(t, "deflate", e[0])
+	assert.Equal(t, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36", opts.Header.Get("User-Agent"))
+}

--- a/gzip_go18_test.go
+++ b/gzip_go18_test.go
@@ -9,8 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSetAcceptEncodingForPushOptionsNil(t *testing.T) {
-
+func TestSetAcceptEncodingForPushOptionsWithoutHeaders(t *testing.T) {
 	var opts *http.PushOptions
 	opts = setAcceptEncodingForPushOptions(opts)
 
@@ -36,7 +35,7 @@ func TestSetAcceptEncodingForPushOptionsNil(t *testing.T) {
 	}
 }
 
-func TestSetAcceptEncodingForPushOptionsNoAcceptEncoding(t *testing.T) {
+func TestSetAcceptEncodingForPushOptionsWithHeaders(t *testing.T) {
 	opts := &http.PushOptions{
 		Header: http.Header{
 			"User-Agent": []string{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36"},
@@ -49,11 +48,8 @@ func TestSetAcceptEncodingForPushOptionsNoAcceptEncoding(t *testing.T) {
 
 	assert.Equal(t, "gzip", opts.Header.Get("Accept-Encoding"))
 	assert.Equal(t, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36", opts.Header.Get("User-Agent"))
-}
 
-func TestSetAcceptEncodingForPushOptionsWithAcceptEncoding(t *testing.T) {
-
-	opts := &http.PushOptions{
+	opts = &http.PushOptions{
 		Header: http.Header{
 			"User-Agent":   []string{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36"},
 			acceptEncoding: []string{"deflate"},

--- a/gzip_go18_test.go
+++ b/gzip_go18_test.go
@@ -9,7 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSetAcceptEncodingForPushOptionsNilOpts(t *testing.T) {
+func TestSetAcceptEncodingForPushOptionsNil(t *testing.T) {
+
 	var opts *http.PushOptions
 	opts = setAcceptEncodingForPushOptions(opts)
 
@@ -21,10 +22,8 @@ func TestSetAcceptEncodingForPushOptionsNilOpts(t *testing.T) {
 		assert.Len(t, v, 1)
 		assert.Equal(t, "gzip", v[0])
 	}
-}
 
-func TestSetAcceptEncodingForPushOptionsNilHeader(t *testing.T) {
-	opts := &http.PushOptions{}
+	opts = &http.PushOptions{}
 	opts = setAcceptEncodingForPushOptions(opts)
 
 	assert.NotNil(t, opts)


### PR DESCRIPTION
add support for H2 Push without removing support for previous Go versions.

#28 