### PR TITLE
Unset gw once closed

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -117,6 +117,7 @@ func (w *GzipResponseWriter) Close() error {
 
 	err := w.gw.Close()
 	gzipWriterPools[w.index].Put(w.gw)
+	w.gw = nil
 	return err
 }
 


### PR DESCRIPTION
If the handler is already closed, then closing it again causes the gzip writer to be in the pool twice and to be closed in the middle of potentially another write.