### PR TITLE
Set the HttpStatus correctly in the response header

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -146,7 +146,7 @@ func (w *GzipResponseWriter) writeHeader() {
 	if w.code == 0 {
 		w.code = http.StatusOK
 	}
-	w.WriteHeader(w.code)
+	w.ResponseWriter.WriteHeader(w.code)
 }
 
 // init graps a new gzip writer from the gzipWriterPool and writes the correct

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -287,6 +287,19 @@ func TestGzipDoubleClose(t *testing.T) {
 	assert.False(t, w1 == w2)
 }
 
+func TestStatusCodes(t *testing.T) {
+	handler := GzipHandler(http.NotFoundHandler())
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	result := w.Result()
+	if result.StatusCode != 404 {
+		t.Errorf("StatusCode should have been 404 but was %d", result.StatusCode)
+	}
+}
+
 // --------------------------------------------------------------------
 
 func BenchmarkGzipHandler_S2k(b *testing.B)   { benchmark(b, false, 2048) }


### PR DESCRIPTION
The HttpStatus was getting lost - every response was a 200 OK because ResponseWriter.WriteHeader() was never called.