### PR TITLE
[WIP] Write the response code before it gets assumed as '200 OK'

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -151,6 +151,7 @@ func (w *GzipResponseWriter) startGzip() error {
 // WriteHeader just saves the response code until close or GZIP effective writes.
 func (w *GzipResponseWriter) WriteHeader(code int) {
 	w.code = code
+	w.ResponseWriter.WriteHeader(code)
 }
 
 // init graps a new gzip writer from the gzipWriterPool and writes the correct


### PR DESCRIPTION
I believe this is what's causing https://github.com/containous/traefik/issues/1937

When the response code isn't written back, subsequent calls through the `ReponseWriter.Write` will make Go assume the response code is `200 OK`.

This is evidenced by the warning message in the logs:

```
2017/08/11 14:31:11 server.go:2753: http: multiple response.WriteHeader calls
```