### PR TITLE
fix handling of responses which are already compressed

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -105,7 +105,7 @@ func (w *GzipResponseWriter) Write(b []byte) (int, error) {
 	// If the global writes are bigger than the minSize and we're about to write
 	// a response containing a content type we want to handle, enable
 	// compression.
-	if len(w.buf) >= w.minSize && handleContentType(w.contentTypes, w) {
+	if len(w.buf) >= w.minSize && handleContentType(w.contentTypes, w) && w.Header().Get(contentEncoding) == "" {
 		err := w.startGzip()
 		if err != nil {
 			return 0, err
@@ -134,7 +134,7 @@ func (w *GzipResponseWriter) startGzip() error {
 	// Initialize the GZIP response.
 	w.init()
 
-	// Flush the buffer into the gzip response.
+	// Flush the buffer into the gzip reponse.
 	n, err := w.gw.Write(w.buf)
 
 	// This should never happen (per io.Writer docs), but if the write didn't


### PR DESCRIPTION
In my case with [Up](https://github.com/apex/up) (reverse proxy) the origin may have already compressed, so it would be safe for this middleware to nop. Let me know if you want anything tweaked!