### PR TITLE
Fix issue on status code when writer flush

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -82,6 +82,7 @@ type GzipResponseWriter struct {
 	buf     []byte // Holds the first part of the write before reaching the minSize or the end of the write.
 
 	contentTypes []string // Only compress if the response is one of these content-types. All are accepted if empty.
+	flushed      bool     // Indicate if the stream was already flushed
 }
 
 // Write appends data to the gzip writer.
@@ -167,7 +168,8 @@ func (w *GzipResponseWriter) init() {
 func (w *GzipResponseWriter) Close() error {
 	if w.gw == nil {
 		// Gzip not trigged yet, write out regular response.
-		if w.code != 0 {
+		// WriteHeader only if it wasn't already wrote by a Flush
+		if !w.flushed && w.code != 0 {
 			w.ResponseWriter.WriteHeader(w.code)
 		}
 		if w.buf != nil {
@@ -195,7 +197,11 @@ func (w *GzipResponseWriter) Flush() {
 	}
 
 	if fw, ok := w.ResponseWriter.(http.Flusher); ok {
+		if !w.flushed && w.code != 0 {
+			w.ResponseWriter.WriteHeader(w.code)
+		}
 		fw.Flush()
+		w.flushed = true
 	}
 }
 

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -306,6 +306,23 @@ func TestStatusCodes(t *testing.T) {
 	}
 }
 
+func TestStatusCodesFlushed(t *testing.T) {
+	handler := GzipHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusNotFound)
+		rw.(http.Flusher).Flush()
+		rw.Write([]byte("Not found"))
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set(acceptEncoding, "gzip")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	result := w.Result()
+	if result.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode should have been 404 but was %d", result.StatusCode)
+	}
+}
+
 func TestDontWriteWhenNotWrittenTo(t *testing.T) {
 	// When using gzip as middleware without ANY writes in the handler,
 	// ensure the gzip middleware doesn't touch the actual ResponseWriter


### PR DESCRIPTION
In the stdlib, when we call `Flush` on a response writer, if the status code header was never wrote, it write a 200 status code

As the `WriteHeader` is buffered in `GzipWriter`, if we call Flush in the handler or in a previous middleware, the status code 200 is send even if we have call `WriteHeader` before flushing.