### PR TITLE
Fix Flush breaks response if called while buffering

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -82,7 +82,6 @@ type GzipResponseWriter struct {
 	buf     []byte // Holds the first part of the write before reaching the minSize or the end of the write.
 
 	contentTypes []string // Only compress if the response is one of these content-types. All are accepted if empty.
-	flushed      bool     // Indicate if the stream was already flushed
 }
 
 // Write appends data to the gzip writer.
@@ -170,8 +169,7 @@ func (w *GzipResponseWriter) init() {
 func (w *GzipResponseWriter) Close() error {
 	if w.gw == nil {
 		// Gzip not trigged yet, write out regular response.
-		// WriteHeader only if it wasn't already wrote by a Flush
-		if !w.flushed && w.code != 0 {
+		if w.code != 0 {
 			w.ResponseWriter.WriteHeader(w.code)
 		}
 		if w.buf != nil {
@@ -199,11 +197,7 @@ func (w *GzipResponseWriter) Flush() {
 	}
 
 	if fw, ok := w.ResponseWriter.(http.Flusher); ok {
-		if !w.flushed && w.code != 0 {
-			w.ResponseWriter.WriteHeader(w.code)
-		}
 		fw.Flush()
-		w.flushed = true
 	}
 }
 

--- a/gzip.go
+++ b/gzip.go
@@ -192,9 +192,15 @@ func (w *GzipResponseWriter) Close() error {
 // http.ResponseWriter if it is an http.Flusher. This makes GzipResponseWriter
 // an http.Flusher.
 func (w *GzipResponseWriter) Flush() {
-	if w.gw != nil {
-		w.gw.Flush()
+	if w.gw == nil {
+		// Only flush once startGzip has been called.
+		//
+		// Flush is thus a no-op until the written body
+		// exceeds minSize.
+		return
 	}
+
+	w.gw.Flush()
 
 	if fw, ok := w.ResponseWriter.(http.Flusher); ok {
 		fw.Flush()

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -306,23 +306,6 @@ func TestStatusCodes(t *testing.T) {
 	}
 }
 
-func TestStatusCodesFlushed(t *testing.T) {
-	handler := GzipHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		rw.WriteHeader(http.StatusNotFound)
-		rw.(http.Flusher).Flush()
-		rw.Write([]byte("Not found"))
-	}))
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	r.Header.Set(acceptEncoding, "gzip")
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, r)
-
-	result := w.Result()
-	if result.StatusCode != http.StatusNotFound {
-		t.Errorf("StatusCode should have been 404 but was %d", result.StatusCode)
-	}
-}
-
 func TestIgnoreSubsequentWriteHeader(t *testing.T) {
 	handler := GzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -306,6 +306,24 @@ func TestStatusCodes(t *testing.T) {
 	}
 }
 
+func TestFlushBeforeWrite(t *testing.T) {
+	b := []byte(testBody)
+	handler := GzipHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusNotFound)
+		rw.(http.Flusher).Flush()
+		rw.Write(b)
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	res := w.Result()
+	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+	assert.Equal(t, "gzip", res.Header.Get("Content-Encoding"))
+	assert.NotEqual(t, b, w.Body.Bytes())
+}
+
 func TestIgnoreSubsequentWriteHeader(t *testing.T) {
 	handler := GzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)


### PR DESCRIPTION
This fixes the bug I noted in https://github.com/NYTimes/gziphandler/pull/58#issuecomment-343036704. In doing so, it reverts 0f67f3f, which was #58, and commits a different fix for that issue.

Where #58 juggled calling `WriteHeader` within `Flush`, this pull request simply makes `Flush` a no-op while the response is buffering, *i.e.* until it reaches the minimum size.

In reverting 0f67f3f, it has the side-effect of reducing the size of the per-request `GzipResponseWriter` struct from 104 bytes to 96 bytes.