### PR TITLE
Need pointer to implement CloseNotifier

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -282,7 +282,7 @@ func GzipHandlerWithOpts(opts ...option) (func(http.Handler) http.Handler, error
 				defer gw.Close()
 
 				if _, ok := w.(http.CloseNotifier); ok {
-					gwcn := GzipResponseWriterWithCloseNotify{gw}
+					gwcn := &GzipResponseWriterWithCloseNotify{gw}
 					h.ServeHTTP(gwcn, r)
 				} else {
 					h.ServeHTTP(gw, r)

--- a/gzip.go
+++ b/gzip.go
@@ -88,7 +88,7 @@ type GzipResponseWriterWithCloseNotify struct {
 	*GzipResponseWriter
 }
 
-func (w *GzipResponseWriterWithCloseNotify) CloseNotify() <-chan bool {
+func (w GzipResponseWriterWithCloseNotify) CloseNotify() <-chan bool {
 	return w.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
 
@@ -282,7 +282,7 @@ func GzipHandlerWithOpts(opts ...option) (func(http.Handler) http.Handler, error
 				defer gw.Close()
 
 				if _, ok := w.(http.CloseNotifier); ok {
-					gwcn := &GzipResponseWriterWithCloseNotify{gw}
+					gwcn := GzipResponseWriterWithCloseNotify{gw}
 					h.ServeHTTP(gwcn, r)
 				} else {
 					h.ServeHTTP(gw, r)

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -325,17 +325,35 @@ func TestFlushBeforeWrite(t *testing.T) {
 }
 
 func TestImplementCloseNotifier(t *testing.T) {
+	request := &http.Request{}
+	request.Header = http.Header{}
+	request.Header.Set(acceptEncoding, "gzip")
 	GzipHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
 		_, ok := rw.(http.CloseNotifier)
 		assert.True(t, ok, "response writer must implement http.CloseNotifier")
-	})).ServeHTTP(&mockRWCloseNotify{}, &http.Request{})
+	})).ServeHTTP(&mockRWCloseNotify{}, request)
+}
+
+func TestImplementFlusherAndCloseNotifier(t *testing.T) {
+	request := &http.Request{}
+	request.Header = http.Header{}
+	request.Header.Set(acceptEncoding, "gzip")
+	GzipHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
+		_, okCloseNotifier := rw.(http.CloseNotifier)
+		assert.True(t, okCloseNotifier, "response writer must implement http.CloseNotifier")
+		_, okFlusher := rw.(http.Flusher)
+		assert.True(t, okFlusher, "response writer must implement http.Flusher")
+	})).ServeHTTP(&mockRWCloseNotify{}, request)
 }
 
 func TestNotImplementCloseNotifier(t *testing.T) {
+	request := &http.Request{}
+	request.Header = http.Header{}
+	request.Header.Set(acceptEncoding, "gzip")
 	GzipHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
 		_, ok := rw.(http.CloseNotifier)
 		assert.False(t, ok, "response writer must not implement http.CloseNotifier")
-	})).ServeHTTP(httptest.NewRecorder(), &http.Request{})
+	})).ServeHTTP(httptest.NewRecorder(), request)
 }
 
 

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -325,8 +325,7 @@ func TestFlushBeforeWrite(t *testing.T) {
 }
 
 func TestImplementCloseNotifier(t *testing.T) {
-	request := &http.Request{}
-	request.Header = http.Header{}
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
 	request.Header.Set(acceptEncoding, "gzip")
 	GzipHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
 		_, ok := rw.(http.CloseNotifier)
@@ -335,8 +334,7 @@ func TestImplementCloseNotifier(t *testing.T) {
 }
 
 func TestImplementFlusherAndCloseNotifier(t *testing.T) {
-	request := &http.Request{}
-	request.Header = http.Header{}
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
 	request.Header.Set(acceptEncoding, "gzip")
 	GzipHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
 		_, okCloseNotifier := rw.(http.CloseNotifier)
@@ -347,8 +345,7 @@ func TestImplementFlusherAndCloseNotifier(t *testing.T) {
 }
 
 func TestNotImplementCloseNotifier(t *testing.T) {
-	request := &http.Request{}
-	request.Header = http.Header{}
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
 	request.Header.Set(acceptEncoding, "gzip")
 	GzipHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request){
 		_, ok := rw.(http.CloseNotifier)


### PR DESCRIPTION
GzipResponseWriterWithCloseNotify doesn't implement CloseNotifier, but *GzipResponseWriterWithCloseNotify does.

Fix the tests to really verify with a request that accept gzip.