### PR TITLE
Fixed double WriteHeader calls caused by #71

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -159,6 +159,8 @@ func (w *GzipResponseWriter) startGzip() error {
 	// Write the header to gzip response.
 	if w.code != 0 {
 		w.ResponseWriter.WriteHeader(w.code)
+		// Ensure that no other WriteHeader's happen
+		w.code = 0
 	}
 
 	// Initialize and flush the buffer into the gzip response if there are any bytes.
@@ -184,6 +186,8 @@ func (w *GzipResponseWriter) startGzip() error {
 func (w *GzipResponseWriter) startPlain() error {
 	if w.code != 0 {
 		w.ResponseWriter.WriteHeader(w.code)
+		// Ensure that no other WriteHeader's happen
+		w.code = 0
 	}
 	w.ignore = true
 	// If Write was never called then don't call Write on the underlying ResponseWriter.


### PR DESCRIPTION
@jprobinson Small change that somehow I missed in #71. Apparently in specific scenarios WriteHeader can be called twice which doesn't actually break anything but causes `http: multiple response.WriteHeader calls` logs. Setting the code to 0 after we call WriteHeader prevents Close from triggering the WriteHeader. I added a test as well to verify.