### PR TITLE
check minsize when writing first byte

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -166,7 +166,7 @@ func (w *GzipResponseWriter) startGzip() error {
 	// Initialize and flush the buffer into the gzip response if there are any bytes.
 	// If there aren't any, we shouldn't initialize it yet because on Close it will
 	// write the gzip header even if nothing was ever written.
-	if len(w.buf) > 0 {
+	if len(w.buf) >= w.minSize {
 		// Initialize the GZIP response.
 		w.init()
 		n, err := w.gw.Write(w.buf)

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -208,6 +208,51 @@ func TestGzipHandlerNoBody(t *testing.T) {
 	}
 }
 
+func TestGzipHnalderStream(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:")
+	if err != nil {
+		t.Fatalf("failed creating listen socket: %v", err)
+	}
+	defer ln.Close()
+	srv := &http.Server{
+		Handler: nil,
+	}
+	go srv.Serve(ln)
+
+	handler, ok := GzipHandlerWithOpts(MinSize(0))
+	assert.Nil(t, ok)
+	srv.Handler = handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		assert.Equal(t, true, ok)
+
+		w.WriteHeader(200)
+		w.Write([]byte(""))
+		flusher.Flush()
+		w.Write([]byte("subsequent write with data"))
+		flusher.Flush()
+	}))
+
+	req := &http.Request{
+		Method: "GET",
+		URL:    &url.URL{Path: "/", Scheme: "http", Host: ln.Addr().String()},
+		Header: make(http.Header),
+		Close:  false,
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Unexpected error making http request %v", err)
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("Unexpected error reading response body %v", err)
+	}
+
+	assert.Equal(t, "subsequent write with data", string(body))
+
+}
 func TestGzipHandlerContentLength(t *testing.T) {
 	testBodyBytes := []byte(testBody)
 	tests := []struct {


### PR DESCRIPTION
Fix bug where writing and flushing a zero byte write would cause startGzip() to run but not write, and then on subsequent writes call startPlain, resulting in invalid header errors