### PR TITLE
Set detected Content-Type only when not already set

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -128,6 +128,12 @@ func (w *GzipResponseWriter) Write(b []byte) (int, error) {
 			// If a Content-Type wasn't specified, infer it from the current buffer.
 			if ct == "" {
 				ct = http.DetectContentType(w.buf)
+			}
+
+			// Handles the intended case of setting a nil Content-Type (as for http/server or http/fs)
+			// Set the header only if the key does not exist
+			_, haveType := w.Header()["Content-Type"]
+			if !haveType {
 				w.Header().Set(contentType, ct)
 			}
 			// If the Content-Type is acceptable to GZIP, initialize the GZIP writer.

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -81,6 +81,21 @@ func TestGzipHandler(t *testing.T) {
 	assert.Equal(t, http.DetectContentType([]byte(testBody)), res3.Header().Get("Content-Type"))
 }
 
+func TestGzipHandlerNilContentType(t *testing.T) {
+	// This just exists to provide something for GzipHandler to wrap.
+	handler := newTestHandler(testBody)
+
+	// content-type header not set when provided nil
+
+	req, _ := http.NewRequest("GET", "/whatever", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	res := httptest.NewRecorder()
+	res.Header()["Content-Type"] = nil
+	handler.ServeHTTP(res, req)
+
+	assert.Empty(t, res.Header().Get("Content-Type"))
+}
+
 func TestGzipHandlerSmallBodyNoCompression(t *testing.T) {
 	handler := newTestHandler(smallTestBody)
 


### PR DESCRIPTION
This PR introduce a condition to set the `Content-Type` header, backed by a new test.

The goal is to have the identical behavior as the [http/server](https://github.com/golang/go/blob/f639a81cd5e85ca9538c76e612867aa4c2ae241b/src/net/http/server.go#L1382) and [http/fs](https://github.com/golang/go/blob/f639a81cd5e85ca9538c76e612867aa4c2ae241b/src/net/http/fs.go#L193) does.

`Content-Type` header will only be set with the detected MIME type if it is not already set, which means no header previously set (at all).
So the condition to set the header is when there is no existing key for the `Content-Type` header in the response writer map.

The purpose of handling the nil value could be seen as the capacity to disable content type detection, and at the same time, not having the `Content-Type` header in the resulting response for the client.