### PR TITLE
Add duplicate vary header check

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -321,7 +321,7 @@ func GzipHandlerWithOpts(opts ...option) (func(http.Handler) http.Handler, error
 		index := poolIndex(c.level)
 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Add(vary, acceptEncoding)
+			w.Header().Set(vary, parseAndModifyVaryHeader(w))
 			if acceptsGzip(r) {
 				gw := &GzipResponseWriter{
 					ResponseWriter: w,
@@ -343,6 +343,21 @@ func GzipHandlerWithOpts(opts ...option) (func(http.Handler) http.Handler, error
 			}
 		})
 	}, nil
+}
+
+func parseAndModifyVaryHeader(w http.ResponseWriter) string {
+	varyHeader := w.Header().Get(vary)
+	if varyHeader == acceptEncoding {
+		return acceptEncoding
+	}
+
+	if varyHeader != "" {
+		varyHeader += ","
+	}
+
+	varyHeader += acceptEncoding
+
+	return varyHeader
 }
 
 // Parsed representation of one of the inputs to ContentTypes.

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -81,6 +81,20 @@ func TestGzipHandler(t *testing.T) {
 	assert.Equal(t, http.DetectContentType([]byte(testBody)), res3.Header().Get("Content-Type"))
 }
 
+func TestGzipHandlerExistingVaryHeader(t *testing.T) {
+	// This just exists to provide something for GzipHandler to wrap.
+	handler := newTestHandler(testBody)
+	req, _ := http.NewRequest("GET", "/whatever", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	res := httptest.NewRecorder()
+
+	// Set the Vary header to a pre-existing value.
+	res.Header().Set(vary, "Origin")
+	handler.ServeHTTP(res, req)
+
+	assert.Equal(t, res.Header().Get(vary), "Origin,"+acceptEncoding)
+}
+
 func TestGzipHandlerSmallBodyNoCompression(t *testing.T) {
 	handler := newTestHandler(smallTestBody)
 


### PR DESCRIPTION
This PR:

- Adds a check to see if the `Vary` header has already been set for the response.
- Modifies the Vary header if needed.
- Sets the header, instead of adding to prevent duplicates.
- Adds a test to confirm that the header is properly set with an upstream header present.

This allows this handler to be used in chains where upstream links may set the Vary header on the response before it is returned to this handler.