### PR TITLE
Adding Power support(ppc64le) with continuous integration/testing so that project stays architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+arch:
+  - ppc64le
+  - amd64
 go:
   - 1.x
   - tip


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,For more info tag @gerrith3.
